### PR TITLE
travis: Python 2.6 removal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,11 @@ services:
 language: python
 
 python:
-  - "2.6"
   - "2.7"
 
 install:
   - "sudo apt-get update"
-  - "sudo apt-get install apache2 libapache2-mod-wsgi ssl-cert poppler-utils --fix-missing"
+  - "sudo apt-get install apache2 libapache2-mod-wsgi libapache2-mod-xsendfile ssl-cert poppler-utils --fix-missing"
   - "sudo a2enmod actions"
   - "sudo a2enmod version"
   - "sudo a2enmod rewrite"


### PR DESCRIPTION
- Removes python 2.6 from the test matrix as it times out.
- Fixes apache2 xsendfile installation.

Signed-off-by: Leonardo Rossi leonardo.r@cern.ch
