### PR TITLE
installation: fix invenio_access import

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -20,6 +20,7 @@ Authors and contributors: (active)
 - Jiri Kuncar <jiri.kuncar@cern.ch>
 - Laura Rueda <laura.rueda@cern.ch>
 - Lars Holm Nielsen <lars.holm.nielsen@cern.ch>
+- Sami Hiltunen <sami.mikael.hiltunen@cern.ch>
 - Sebastian Witowski <sebastian.witowski@cern.ch>
 - Wojciech Ziolek <wojciech.ziolek@cern.ch>
 - Grzegorz Szpura <grzegorz.szpura@cern.ch>

--- a/invenio_demosite/modules/access/config.py
+++ b/invenio_demosite/modules/access/config.py
@@ -19,7 +19,7 @@
 
 """Access module configuration values."""
 
-from invenio.modules.access.local_config import VIEWRESTRCOLL
+from invenio_access.local_config import VIEWRESTRCOLL
 
 # Demo site roles
 DEF_DEMO_ROLES = (

--- a/invenio_demosite/testsuite/regression/test_bibdocfile.py
+++ b/invenio_demosite/testsuite/regression/test_bibdocfile.py
@@ -32,7 +32,7 @@ from invenio.testsuite import InvenioTestCase, make_test_suite, run_test_suite
 
 from invenio.utils.mimetype import CFG_HAS_MAGIC
 
-CFG_WEBACCESS_WARNING_MSGS = lazy_import('invenio.modules.access.local_config:CFG_WEBACCESS_WARNING_MSGS')
+CFG_WEBACCESS_WARNING_MSGS = lazy_import('invenio_access.local_config:CFG_WEBACCESS_WARNING_MSGS')
 MoreInfo = lazy_import('invenio.legacy.bibdocfile.api:MoreInfo')
 Md5Folder = lazy_import('invenio.legacy.bibdocfile.api:Md5Folder')
 guess_format_from_url = lazy_import('invenio.legacy.bibdocfile.api:guess_format_from_url')

--- a/invenio_demosite/testsuite/regression/test_bibupload.py
+++ b/invenio_demosite/testsuite/regression/test_bibupload.py
@@ -4043,7 +4043,7 @@ allow any</subfield>
     def test_exotic_format_fft_append(self):
         """bibupload - exotic format FFT append"""
         # define the test case:
-        from invenio.modules.access.local_config import CFG_ACC_GRANT_AUTHOR_RIGHTS_TO_EMAILS_IN_TAGS
+        from invenio_access.local_config import CFG_ACC_GRANT_AUTHOR_RIGHTS_TO_EMAILS_IN_TAGS
         testfile = os.path.join(cfg['CFG_TMPDIR'], 'test.ps.Z')
         open(testfile, 'w').write('TEST')
         email_tag = CFG_ACC_GRANT_AUTHOR_RIGHTS_TO_EMAILS_IN_TAGS[0][0:3]
@@ -4260,7 +4260,7 @@ allow any</subfield>
     def test_simple_fft_insert_with_restriction(self):
         """bibupload - simple FFT insert with restriction"""
         # define the test case:
-        from invenio.modules.access.local_config import CFG_ACC_GRANT_AUTHOR_RIGHTS_TO_EMAILS_IN_TAGS
+        from invenio_access.local_config import CFG_ACC_GRANT_AUTHOR_RIGHTS_TO_EMAILS_IN_TAGS
         email_tag = CFG_ACC_GRANT_AUTHOR_RIGHTS_TO_EMAILS_IN_TAGS[0][0:3]
         email_ind1 = CFG_ACC_GRANT_AUTHOR_RIGHTS_TO_EMAILS_IN_TAGS[0][3]
         email_ind2 = CFG_ACC_GRANT_AUTHOR_RIGHTS_TO_EMAILS_IN_TAGS[0][4]
@@ -5542,7 +5542,7 @@ allow any</subfield>
     def test_revert_fft_correct(self):
         """bibupload - revert FFT correct"""
         # define the test case:
-        from invenio.modules.access.local_config import CFG_ACC_GRANT_AUTHOR_RIGHTS_TO_EMAILS_IN_TAGS
+        from invenio_access.local_config import CFG_ACC_GRANT_AUTHOR_RIGHTS_TO_EMAILS_IN_TAGS
         email_tag = CFG_ACC_GRANT_AUTHOR_RIGHTS_TO_EMAILS_IN_TAGS[0][0:3]
         email_ind1 = CFG_ACC_GRANT_AUTHOR_RIGHTS_TO_EMAILS_IN_TAGS[0][3]
         email_ind2 = CFG_ACC_GRANT_AUTHOR_RIGHTS_TO_EMAILS_IN_TAGS[0][4]
@@ -5672,7 +5672,7 @@ allow any</subfield>
     def test_simple_fft_replace(self):
         """bibupload - simple FFT replace"""
         # define the test case:
-        from invenio.modules.access.local_config import CFG_ACC_GRANT_AUTHOR_RIGHTS_TO_EMAILS_IN_TAGS
+        from invenio_access.local_config import CFG_ACC_GRANT_AUTHOR_RIGHTS_TO_EMAILS_IN_TAGS
         email_tag = CFG_ACC_GRANT_AUTHOR_RIGHTS_TO_EMAILS_IN_TAGS[0][0:3]
         email_ind1 = CFG_ACC_GRANT_AUTHOR_RIGHTS_TO_EMAILS_IN_TAGS[0][3]
         email_ind2 = CFG_ACC_GRANT_AUTHOR_RIGHTS_TO_EMAILS_IN_TAGS[0][4]

--- a/invenio_demosite/testsuite/regression/test_webaccess.py
+++ b/invenio_demosite/testsuite/regression/test_webaccess.py
@@ -88,8 +88,8 @@ class WebAccessFireRoleTest(InvenioTestCase):
 
     def setUp(self):
         """Create a fake role."""
-        from invenio.modules.access.control import acc_add_role
-        from invenio.modules.access.firerole import compile_role_definition, \
+        from invenio_access.control import acc_add_role
+        from invenio_access.firerole import compile_role_definition, \
             serialize
         self.role_name = 'test'
         self.role_description = 'test role'
@@ -101,13 +101,13 @@ class WebAccessFireRoleTest(InvenioTestCase):
 
     def tearDown(self):
         """Drop the fake role."""
-        from invenio.modules.access.control import acc_delete_role
+        from invenio_access.control import acc_delete_role
         acc_delete_role(self.role_id)
 
     def test_webaccess_firerole_serialization(self):
         """webaccess - firerole role definition correctly serialized"""
-        from invenio.modules.access.control import acc_get_role_definition
-        from invenio.modules.access.firerole import compile_role_definition, \
+        from invenio_access.control import acc_get_role_definition
+        from invenio_access.firerole import compile_role_definition, \
             deserialize
         def_ser = compile_role_definition(self.role_definition)
         tmp_def_ser = acc_get_role_definition(self.role_id)
@@ -146,7 +146,7 @@ if False: #FIXME cfg['CFG_DEVEL_SITE']:
                 run_sql("DELETE FROM userEXT WHERE id=%s", (nickname, ))
 
         def setUp(self):
-            from invenio.modules.access.local_config import CFG_EXTERNAL_AUTHENTICATION
+            from invenio_access.local_config import CFG_EXTERNAL_AUTHENTICATION
             self.robot_login_methods = dict([(method_name, CFG_EXTERNAL_AUTHENTICATION[method_name]) for method_name in CFG_EXTERNAL_AUTHENTICATION if CFG_EXTERNAL_AUTHENTICATION[method_name] and CFG_EXTERNAL_AUTHENTICATION[method_name].robot_login_method_p()])
             self.a_robot = "regression-test"
             self.a_password = "123"


### PR DESCRIPTION
- Adds missing `invenio_access` dependency and amends past upgrade
  recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
